### PR TITLE
[Server] / #42, 38, 33, 28, 26, 23  Feat: 챌린지 삭제,체크인,댓글,챌린지참여

### DIFF
--- a/server/controllers/badges.js
+++ b/server/controllers/badges.js
@@ -1,36 +1,27 @@
-const { isAuthorized } = require("./tokenFunctions");
-const { users_badge: UserBadgeModel } = require("../models");
+const { isAuthorized } = require('./tokenFunctions');
+const { users_badge: UserBadgeModel } = require('../models');
 
 module.exports = {
-  patch: (req, res) => {
+  patch: async (req, res) => {
     try {
-      if (req.headers["authorization"] && authorization.split(" ")[1]) {
+      if (isAuthorized(req)) {
         const userInfo = JSON.parse(isAuthorized(req).data);
         const userId = userInfo.id;
         const badgeArray = req.body.badge_ids;
-        UserBadgeModel.update({
-          where: { user_id: userId },
-        })
-          .then((result) => {
-            return result.update({ is_selected: false });
-          })
-          .then(() => {
-            badgeArray.forEach((badgeId) => {
-              UserBadgeModel.findOne({
-                where: { user_id: userId, badge_id: badgeId },
-              });
-            });
-          })
-          .then((result) => {
-            result.update({ is_selected: true });
-            console.log("####", result);
-          });
+        console.log('USER ID', userId);
+
+        //   for (let badgeId in badgeArray) {
+        //     UserBadgeModel.findOne({
+        //       where: { user_id: userId, badge_id: badgeId },
+        //     });
+        //   }
+        // })
       } else {
-        res.status(401).json({ message: "Invalid token" });
+        res.status(401).json({ message: 'Invalid token' });
       }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
     res.send();

--- a/server/controllers/challenges.js
+++ b/server/controllers/challenges.js
@@ -1,13 +1,14 @@
 const {
   challenge: ChallengeModel,
   users_challenge: UserChallengeModel,
+  comment: CommentModel,
+  checkin: CheckInModel,
   sequelize,
-} = require("../models");
-var express = require("express");
+} = require('../models');
+var express = require('express');
 var router = express.Router();
-const { Op } = require("sequelize"); //sequelize or 쓸때 필요합니다.
-const { isAuthorized } = require("./tokenFunctions");
-const { verify } = require("jsonwebtoken");
+const { Op } = require('sequelize'); //sequelize or 쓸때 필요합니다.
+const { isAuthorized } = require('./tokenFunctions');
 
 module.exports = {
   //인기 챌린지 목록 불러오기 GET /challenges/popular/?query=검색어&limit=3
@@ -18,17 +19,17 @@ module.exports = {
         //!query search 아직 미완성
         const search = req.query.query;
         var searchModel = await ChallengeModel.findAll({
-          attributes: ["name", "content", "id"],
+          attributes: ['name', 'content', 'id'],
           raw: true,
         });
       }
       const joinCountArray = await UserChallengeModel.findAll({
         attributes: [
-          [sequelize.fn("COUNT", sequelize.col("user_id")), "JOIN COUNT"],
-          "challenge_id",
+          [sequelize.fn('COUNT', sequelize.col('user_id')), 'JOIN COUNT'],
+          'challenge_id',
         ],
-        group: ["challenge_id"],
-        order: [[sequelize.col("JOIN COUNT"), "DESC"]],
+        group: ['challenge_id'],
+        order: [[sequelize.col('JOIN COUNT'), 'DESC']],
         raw: true,
       });
       const limitNum = req.query.limit || 10;
@@ -41,16 +42,16 @@ module.exports = {
         }).then((result) =>
           popularResult.push(
             Object.assign(result, {
-              "join count": slicedJoinCount[i]["JOIN COUNT"],
+              join_count: slicedJoinCount[i]['JOIN COUNT'],
             })
           )
         );
       }
-      res.status(200).json({ message: "OK", data: popularResult });
+      res.status(200).json({ message: 'OK', data: popularResult });
     } catch (err) {
-      console.log("ERROR", err);
+      console.log('ERROR', err);
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
@@ -62,17 +63,17 @@ module.exports = {
         //!query search 아직 미완성
         const search = req.query.query;
         var searchModel = await ChallengeModel.findAll({
-          attributes: ["name", "content", "id"],
+          attributes: ['name', 'content', 'id'],
           raw: true,
         });
       }
       const joinCountArray = await UserChallengeModel.findAll({
         attributes: [
-          [sequelize.fn("COUNT", sequelize.col("user_id")), "JOIN COUNT"],
-          "challenge_id",
+          [sequelize.fn('COUNT', sequelize.col('user_id')), 'JOIN COUNT'],
+          'challenge_id',
         ],
-        group: ["challenge_id"],
-        order: [["challenge_id", "ASC"]],
+        group: ['challenge_id'],
+        order: [['challenge_id', 'ASC']],
         raw: true,
       });
       const limitNum = req.query.limit || 10;
@@ -85,18 +86,18 @@ module.exports = {
         }).then((result) =>
           latestResult.push(
             Object.assign(result, {
-              "join count": slicedJoinCount[i]["JOIN COUNT"],
+              join_count: slicedJoinCount[i]['JOIN COUNT'],
             })
           )
         );
       }
       res.status(200).send({
-        message: "OK",
+        message: 'OK',
         data: latestResult,
       });
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
@@ -122,7 +123,7 @@ module.exports = {
           })
           .then((NewChallenge) => {
             res.status(200).json({
-              message: "OK",
+              message: 'OK',
               data: {
                 id: NewChallenge.id,
                 name: NewChallenge.name,
@@ -130,11 +131,11 @@ module.exports = {
             });
           });
       } else {
-        res.status(401).json({ message: "Invalid token" });
+        res.status(401).json({ message: 'Invalid token' });
       }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
@@ -143,18 +144,18 @@ module.exports = {
     try {
       var is_joined = false;
       const joinCountArray = await UserChallengeModel.findAll({
-        attributes: ["user_id"],
+        attributes: ['user_id'],
         where: { challenge_id: req.params.challenge_id },
       });
       const join_count = joinCountArray.length;
       const NewChallenge = await ChallengeModel.findOne({
         attributes: [
-          "id",
-          "name",
-          "content",
-          "started_at",
-          "requirement",
-          "createdAt",
+          'id',
+          'name',
+          'content',
+          'started_at',
+          'requirement',
+          'createdAt',
         ],
         where: {
           id: req.params.challenge_id,
@@ -165,7 +166,7 @@ module.exports = {
         const userInfo = JSON.parse(authorization.data);
         const userId = userInfo.id;
         const findIsJoined = await UserChallengeModel.findOne({
-          attributes: ["id"],
+          attributes: ['id'],
           where: { user_id: userId, challenge_id: req.params.challenge_id },
         });
         if (findIsJoined) {
@@ -174,7 +175,7 @@ module.exports = {
       }
       if (NewChallenge) {
         res.status(200).json({
-          message: "OK",
+          message: 'OK',
           data: {
             ...NewChallenge.dataValues,
             join_count: join_count,
@@ -182,122 +183,286 @@ module.exports = {
           },
         });
       } else {
-        res.status(404).json({ message: "Not found" });
+        res.status(404).json({ message: 'Not found' });
       }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
 
-  //?챌린지 수정하기 PATCH /:challenge_id
+  //챌린지 수정하기 PATCH /:challenge_id
   edit: async (req, res) => {
     try {
-      const ChallengeUpdate = await ChallengeModel.update(
-        {
-          name: req.body.name,
-          content: req.body.content,
-          started_at: req.body.started_at,
-          requirement: req.body.requirement,
-        },
-        { where: { id: req.params.challenge_id } }
-      );
-      const ChallengeBring = await ChallengeModel.findOne({
-        where: { id: req.params.challenge_id },
-      });
-      if (ChallengeBring) {
-        return res.status(200).json({
-          message: "OK",
+      if (isAuthorized(req)) {
+        const ChallengeUpdate = await ChallengeModel.update(
+          {
+            name: req.body.name,
+            content: req.body.content,
+            started_at: req.body.started_at,
+            requirement: req.body.requirement,
+          },
+          { where: { id: req.params.challenge_id } }
+        );
+        const UpdateResult = await ChallengeModel.findOne({
+          where: { id: req.params.challenge_id },
+          raw: true,
+        });
+        res.status(200).json({
+          message: 'OK',
           data: {
-            id: ChallengeBring.id,
-            name: ChallengeBring.name,
-            started_at: ChallengeBring.started_at,
-            requirement: ChallengeBring.requirement,
+            id: UpdateResult.id,
+            name: UpdateResult.name,
+            content: UpdateResult.content,
+            started_at: UpdateResult.started_at,
+            requirement: UpdateResult.requirement,
           },
         });
       } else {
         res.status(401).json({
-          message: "Invalid token",
+          message: 'Invalid token',
         });
       }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
-  //!챌린지 삭제하기 DELETE /:challenge_id 보류
-  delete: async (req, res) => {
+  //챌린지 삭제하기 DELETE /:challenge_id 보류
+  delete: (req, res) => {
     try {
-      const NewChallenge = await ChallengeModel.findOne({
-        where: {
-          id: req.params.challenge_id,
-        },
-      });
-
-      if (NewChallenge) {
-        const Delete = ChallengeModel.destroy({
+      if (isAuthorized(req)) {
+        ChallengeModel.destroy({
           where: {
             id: req.params.challenge_id,
           },
-        });
-        return res.status(204).json({
-          message: "OK",
+        }).then(() => {
+          return res.status(204); //응답 바디 없음
         });
       } else {
         res.status(401).json({
-          message: "Invalid token",
+          message: 'Invalid token',
         });
       }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
-  //!체크인(인증) 확인하기 GET /:challenge_id/checkins
+  //체크인(인증) 확인하기 GET /:challenge_id/checkins
   checkins: async (req, res) => {
     try {
-      const NewChallenge = await ChallengeModel.findOne({
-        where: {
-          id: req.params.challenge_id,
-        },
-      });
-      if (NewChallenge) {
-        return res.status(204).json({
-          message: "OK",
-          data: {
-            comments: [],
-          },
+      const authorization = isAuthorized(req);
+      const userInfo = JSON.parse(authorization.data);
+      const userId = userInfo.id;
+      var join_count = 0;
+      var total_checkin_count = 0;
+      // if (isAuthorized(req)) { //!토큰 확인 필요??
+      UserChallengeModel.findOne({
+        attributes: [
+          [sequelize.fn('COUNT', sequelize.col('user_id')), 'JOIN COUNT'],
+          'challenge_id',
+        ],
+        group: ['challenge_id'],
+        order: [[sequelize.col('JOIN COUNT'), 'DESC']],
+        raw: true,
+        where: { challenge_id: req.params.challenge_id },
+      })
+        .then((result) => {
+          join_count = result['JOIN COUNT'];
+          return CheckInModel.create({
+            user_id: userId,
+            content: req.body.content,
+            challenge_id: req.params.challenge_id,
+          });
+        })
+        .then((result) => {
+          return CheckInModel.findAll({
+            attributes: ['createdAt'],
+            where: { challenge_id: req.params.challenge_id },
+            raw: true,
+          });
+        })
+        .then((result) => {
+          total_checkin_count = result.length;
+          return CheckInModel.findAll({
+            attributes: ['createdAt'],
+            where: { user_id: userId, challenge_id: req.params.challenge_id },
+            raw: true,
+          });
+        })
+        .then((result) => {
+          const checkin_log = [];
+          for (let element of result) {
+            checkin_log.push(element.createdAt);
+          }
+          return res.status(200).json({
+            message: 'OK',
+            data: {
+              join_count: join_count,
+              checkin_count: total_checkin_count,
+              checkin_log: checkin_log,
+            },
+          });
         });
-      } else {
-        res.status(401).json({
-          message: "Invalid token",
-        });
-      }
+      // }else { //토큰확인한다면 다시 살려야함.
+      //   res.status(401).json({
+      //     message: "Invalid token",
+      //   });
+      // }
     } catch (err) {
       res.status(500).send({
-        message: "Internal server error",
+        message: 'Internal server error',
       });
     }
   },
   comments: {
     //댓글 목록 불러오기 GET /:challenge_id/comments
     get: async (req, res) => {
-      res.send();
+      try {
+        const commentList = await CommentModel.findAll({
+          attributes: ['id', 'user_id', 'challenge_id', 'content', 'createdAt'],
+          where: { challenge_id: req.params.challenge_id },
+          raw: true,
+        });
+        const result = [];
+        for (let element of commentList) {
+          result.push({
+            comment_id: element.id,
+            user_id: element.user_id,
+            challenge_id: element.challenge_id,
+            content: element.content,
+            created_at: element.createdAt,
+          });
+        }
+        res.status(200).json({
+          message: 'OK',
+          data: {
+            comments: result,
+          },
+        });
+      } catch {
+        res.status(500).json({ message: 'Internal server error' });
+      }
     },
     //댓글 수정하기 PATCH /:challenge_id/comments/:comment_id
     patch: async (req, res) => {
-      res.send();
+      try {
+        if (!isAuthorized(req)) {
+          res.status(401).json({ message: 'Invalid token' });
+        } else {
+          const authorization = isAuthorized(req);
+          const userInfo = JSON.parse(authorization.data);
+          const userId = userInfo.id;
+          const findFirst = await CommentModel.findOne({
+            attributes: ['user_id'],
+            where: {
+              challenge_id: req.params.challenge_id,
+              id: req.params.comment_id,
+            },
+            raw: true,
+          });
+          if (findFirst.user_id === userId) {
+            const changedComment = await CommentModel.update(
+              {
+                content: req.body.content,
+              },
+              { where: { id: req.params.comment_id } }
+            );
+            const changedResult = await CommentModel.findOne({
+              attributes: ['content'],
+              where: { id: req.params.comment_id },
+            });
+            res.status(200).json({ message: 'OK', data: changedResult });
+          } else {
+            res.status(401).json({ message: 'Invalid token' });
+          }
+        }
+      } catch {
+        res.status(500).json({ message: 'Internal server error' });
+      }
     },
     //댓글 삭제하기 DELETE /:challenge_id/comments/:comment_id
     delete: async (req, res) => {
-      res.send();
+      try {
+        if (!isAuthorized(req)) {
+          res.status(401).json({ message: 'Invalid token' });
+        } else {
+          const authorization = isAuthorized(req);
+          const userInfo = JSON.parse(authorization.data);
+          const userId = userInfo.id;
+          const findFirst = await CommentModel.findOne({
+            attributes: ['user_id'],
+            where: {
+              challenge_id: req.params.challenge_id,
+              id: req.params.comment_id,
+            },
+            raw: true,
+          });
+          console.log('USER ID', userId);
+          console.log('findFirst.user_id', findFirst.user_id);
+          if (findFirst.user_id === userId) {
+            await CommentModel.destroy({
+              where: { id: req.params.comment_id },
+            });
+            res.sendStatus(204);
+          } else {
+            res.status(401).json({ message: 'Invalid token' });
+          }
+        }
+      } catch {
+        res.status(500).json({ message: 'Internal server error' });
+      }
     },
     //댓글 작성하기 POST /:challenge_id/comments
     post: async (req, res) => {
-      res.send();
+      try {
+        if (!isAuthorized(req)) {
+          res.status(401).json({ message: 'Invalid token' });
+        } else {
+          const authorization = isAuthorized(req);
+          const userInfo = JSON.parse(authorization.data);
+          const userId = userInfo.id;
+          const postComment = await CommentModel.create({
+            user_id: userId,
+            challenge_id: req.params.challenge_id,
+            content: req.body.content,
+          });
+          res
+            .status(201)
+            .json({ message: 'OK', data: { content: postComment.content } });
+        }
+      } catch {
+        res.status(500).json({ message: 'Internal server error' });
+      }
     },
+  },
+  join: async (req, res) => {
+    try {
+      if (!isAuthorized(req)) {
+        res.status(401).json({ message: 'Invalid token' });
+      } else {
+        const authorization = isAuthorized(req);
+        const userInfo = JSON.parse(authorization.data);
+        const userId = userInfo.id;
+        await UserChallengeModel.create({
+          user_id: userId,
+          challenge_id: req.params.challenge_id,
+        });
+        const findJoinedChallenge = await ChallengeModel.findOne({
+          attributes: ['id', 'name', 'content', 'started_at', 'requirement'],
+          where: {
+            id: req.params.challenge_id,
+          },
+          raw: true,
+        });
+        res.status(200).json({ message: 'OK', data: findJoinedChallenge });
+      }
+    } catch {
+      res.status(500).json({ message: 'Internal server error' });
+    }
   },
 };

--- a/server/migrations/20220103072601-create-checkin.js
+++ b/server/migrations/20220103072601-create-checkin.js
@@ -33,7 +33,7 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
       },
       updatedAt: {
         allowNull: false,

--- a/server/models/badge.js
+++ b/server/models/badge.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      badge.hasMany(models.users_badge);
+      models.badge.hasMany(models.users_badge);
     }
   }
   badge.init(

--- a/server/models/challenge.js
+++ b/server/models/challenge.js
@@ -9,9 +9,9 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      challenge.hasMany(models.users_challenge);
-      challenge.hasMany(models.checkin);
-      challenge.hasMany(models.comment);
+      models.challenge.hasMany(models.users_challenge);
+      models.challenge.hasMany(models.checkin);
+      models.challenge.hasMany(models.comment);
     }
   }
   challenge.init(

--- a/server/models/checkin.js
+++ b/server/models/checkin.js
@@ -15,6 +15,8 @@ module.exports = (sequelize, DataTypes) => {
   }
   checkin.init(
     {
+      user_id: DataTypes.INTEGER,
+      challenge_id: DataTypes.INTEGER,
       content: DataTypes.STRING,
     },
     {

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -9,12 +9,14 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      comment.belongsTo(models.challenge);
-      comment.belongsTo(models.user);
+      models.comment.belongsTo(models.challenge);
+      models.comment.belongsTo(models.user);
     }
   }
   comment.init(
     {
+      user_id: DataTypes.INTEGER,
+      challenge_id: DataTypes.INTEGER,
       content: DataTypes.STRING,
     },
     {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -9,16 +9,16 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      user.hasMany(models.users_challenge, {
+      models.user.hasMany(models.users_challenge, {
         foreignKey: "id",
       });
-      user.hasMany(models.checkin, {
+      models.user.hasMany(models.checkin, {
         foreignKey: "id",
       });
-      user.hasMany(models.comment, {
+      models.user.hasMany(models.comment, {
         foreignKey: "id",
       });
-      user.hasMany(models.users_badge, {
+      models.user.hasMany(models.users_badge, {
         foreignKey: "id",
       });
     }

--- a/server/models/users_badge.js
+++ b/server/models/users_badge.js
@@ -15,6 +15,8 @@ module.exports = (sequelize, DataTypes) => {
   }
   users_badge.init(
     {
+      user_id: DataTypes.INTEGER,
+      badge_id: DataTypes.INTEGER,
       is_selected: DataTypes.BOOLEAN,
     },
     {

--- a/server/models/users_challenge.js
+++ b/server/models/users_challenge.js
@@ -9,8 +9,8 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      users_challenge.belongsTo(models.challenge);
-      users_challenge.belongsTo(models.user);
+      models.users_challenge.belongsTo(models.challenge);
+      models.users_challenge.belongsTo(models.user);
     }
   }
   users_challenge.init(

--- a/server/routes/challenges.js
+++ b/server/routes/challenges.js
@@ -20,7 +20,7 @@ router.patch("/:challenge_id", challenges.edit);
 router.delete("/:challenge_id", challenges.delete);
 
 //체크인(인증) 확인하기
-router.get("/:challenge_id/checkins", challenges.checkins);
+router.post("/:challenge_id/checkins", challenges.checkins); //! 포스트로 변경??
 
 //댓글 목록 불러오기
 router.get("/:challenge_id/comments", challenges.comments.get);
@@ -36,5 +36,8 @@ router.delete(
 
 //댓글 작성하기
 router.post("/:challenge_id/comments", challenges.comments.post);
+
+//챌린지 참가하기
+router.post("/:challenge_id", challenges.join);
 
 module.exports = router;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요) 
- [x] 기능 추가 
- [ ] 기능 삭제 
- [ ] 버그 수정 
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/2stChallenges -> dev
(이름을 잘못지었습니다;;;;)

### 변경 사항
1. 챌린지 삭제하기
2. 체크인하기
3. 댓글 조회, 생성,수정, 삭제
4. 챌린지 참여하기

### 이야기 할 것
1. 챌린지 수정이나 삭제는 작성자만 가능해야할거같은데 챌린지 테이블에는 작성자 정보가 없습니다. 
2. 체크인할때 응답에 401은 없는데 클라이언트에서 이미 걸러서 보내주나요?
3. 체크인 할때 content 짧은 글 적기로 했었는데, 현재 API는 get으로 되어있습니다. 코드 구현은 post로 했습니다. API 수정하겠습니다.
4. 뱃지 획득 API는 없는데 클라이언트에서 해주시나요?